### PR TITLE
CompatHelper: add new compat entry for ArgParse at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -47,6 +47,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 Adapt = "4.1.1"
 ArgCheck = "2.4.0"
+ArgParse = "1"
 CUDA = "5.3.3"
 Cthulhu = "2.16.5"
 DataStructures = "0.18.22"


### PR DESCRIPTION
This pull request sets the compat entry for the `ArgParse` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.