### PR TITLE
CompatHelper: add new compat entry for Makie at version 0.24, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,6 +52,7 @@ Cthulhu = "2.16.5"
 DataStructures = "0.18.22"
 Infiltrator = "1.8.3"
 KernelAbstractions = "0.9.33"
+Makie = "0.24"
 OrdinaryDiffEq = "6.90.1"
 julia = "1.10.2"
 


### PR DESCRIPTION
This pull request sets the compat entry for the `Makie` package to `0.24`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.