### PR TITLE
CompatHelper: add new compat entry for Richardson at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -53,6 +53,7 @@ DataStructures = "0.18.22"
 Infiltrator = "1.8.3"
 KernelAbstractions = "0.9.33"
 OrdinaryDiffEq = "6.90.1"
+Richardson = "1"
 julia = "1.10.2"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `Richardson` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.