### PR TITLE
CompatHelper: add new compat entry for Accessors at version 0.1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -45,6 +45,7 @@ TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+Accessors = "0.1"
 Adapt = "4.1.1"
 ArgCheck = "2.4.0"
 CUDA = "5.3.3"


### PR DESCRIPTION
This pull request sets the compat entry for the `Accessors` package to `0.1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.