### PR TITLE
Prefer PreparedSimulation over raw define_functions in docs/scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ julia> simulation = load_obj_hdf5(file["t2=0.2"]); close(file)
 ```
 Choose either the CPU (`LinearChunked(nkchunks::Integer,...)`) or the GPU solver(`LinearCUDA(nkchunks::Integer,...)`) 
 ```julia
-julia> solver = LinearChunked(); functions = define_functions(simulation, solver)
+julia> solver = LinearChunked(); psim = PreparedSimulation(simulation, solver)
 ```
 and run simulation with
 ```julia
-julia> results = run!(simulation, functions, solver; savepath = "Fig2_rerun")
+julia> results = run!(psim; savepath = "Fig2_rerun")
 ```
 An example script with data is located at `scripts/published_calculations/reproduce.jl`.
 

--- a/scripts/benchmark_bottleneck.jl
+++ b/scripts/benchmark_bottleneck.jl
@@ -16,14 +16,6 @@ function myrun!(
     return invokelatest(Damysos.run!, sim, define_functions(sim, solver), solver; kwargs...)
 end
 
-function preparedrun!(
-    sim::Simulation,
-    functions::Damysos.SimulationFunctions,
-    solver::DamysosSolver = LinearChunked();
-    kwargs...)
-    return Damysos.run!(PreparedSimulation(sim, solver, functions); kwargs...)
-end
-
 function run_silently!(
     runner,
     sim::Simulation,
@@ -73,8 +65,6 @@ function benchmark_solver(
         samples = samples))
     show_trial("myrun! (invokelatest bottleneck)", benchmark_runner(myrun!, sim_template, functions, solver;
         samples = samples))
-    show_trial("run!(psim) - PreparedSimulation (no invokelatest)",
-        benchmark_runner(preparedrun!, sim_template, functions, solver; samples = samples))
 end
 
 const CPU_SIM = make_test_simulation_2d(; id = "sim2d_cpu_bench")

--- a/scripts/benchmark_bottleneck.jl
+++ b/scripts/benchmark_bottleneck.jl
@@ -16,6 +16,14 @@ function myrun!(
     return invokelatest(Damysos.run!, sim, define_functions(sim, solver), solver; kwargs...)
 end
 
+function preparedrun!(
+    sim::Simulation,
+    functions::Damysos.SimulationFunctions,
+    solver::DamysosSolver = LinearChunked();
+    kwargs...)
+    return Damysos.run!(PreparedSimulation(sim, solver, functions); kwargs...)
+end
+
 function run_silently!(
     runner,
     sim::Simulation,
@@ -65,6 +73,8 @@ function benchmark_solver(
         samples = samples))
     show_trial("myrun! (invokelatest bottleneck)", benchmark_runner(myrun!, sim_template, functions, solver;
         samples = samples))
+    show_trial("run!(psim) - PreparedSimulation (no invokelatest)",
+        benchmark_runner(preparedrun!, sim_template, functions, solver; samples = samples))
 end
 
 const CPU_SIM = make_test_simulation_2d(; id = "sim2d_cpu_bench")

--- a/scripts/demo.jl
+++ b/scripts/demo.jl
@@ -52,12 +52,12 @@ end
 const sim = make_demo_simulation()
 const logger = make_teelogger(pwd(),sim.id)
 const solver = LinearChunked(1_024)
-const fns = define_functions(sim,solver)
+const psim = PreparedSimulation(sim,solver)
 
 global_logger(logger)
 @info "$(now())\nOn $(gethostname()):"
 
-const results,time,rest... = @timed run!(sim,fns,solver;savepath="scripts/demodata")
+const results,time,rest... = @timed run!(psim;savepath="scripts/demodata")
 
 @info "$(time/60.)min spent in run!(...)"
 @debug rest

--- a/scripts/published_calculations/reproduce.jl
+++ b/scripts/published_calculations/reproduce.jl
@@ -27,9 +27,9 @@ end
 # Choose chunk size according to available memory
 
 const solver = LinearChunked(1_024)
-const fns = define_functions(simulation,solver)
+const psim = PreparedSimulation(simulation,solver)
 
 # Run the simulation
-const results = run!(simulation,fns,solver; 
+const results = run!(psim;
     savepath="scripts/reproduced_data",
     saveplots=false)

--- a/scripts/published_calculations/semiconductor_toy_1d.jl
+++ b/scripts/published_calculations/semiconductor_toy_1d.jl
@@ -40,5 +40,5 @@ const solver = if CUDA.functional()
 else
     LinearChunked()
 end
-const fns = define_functions(sim,solver)
-const res = run!(sim, fns, solver; savepath="SC_toy1d")
+const psim = PreparedSimulation(sim,solver)
+const res = run!(psim; savepath="SC_toy1d")


### PR DESCRIPTION
The README, demo.jl, published_calculations scripts, and the world-age
bottleneck benchmark still only demonstrated the old define_functions +
3-arg run! workflow, even though PreparedSimulation is now the
recommended entry point. Switch these to PreparedSimulation and add a
third benchmark arm showing run!(psim) avoids the invokelatest
bottleneck that myrun! demonstrates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013yLjL74GFgMCjXrP615Pa4