### PR TITLE
SemiconductorToy1d: document half-gap convention, rename arg to halfgap

### DIFF
--- a/src/hamiltonians/SemiconductorToy1d.jl
+++ b/src/hamiltonians/SemiconductorToy1d.jl
@@ -7,9 +7,13 @@ A toy model for a 1D semiconductor with a direct bandgap at the Brillouin zone c
 
 The Hamiltonian reads 
 ```math
-\\hat{H} = \\frac{\\Delta}{2}\\sigma_x - t \\sin(a k_x/2)\\sigma_z
+\\hat{H} = \\Delta\\sigma_x - t \\sin(a k_x/2)\\sigma_z
 ``` 
-with kx=0 the BZ center. The default values when given a [`UnitScaling`](@ref UnitScaling)
+with kx=0 the BZ center. Note that ``\\Delta`` is **half** the direct bandgap: the band
+splitting of a [`GeneralTwoBand`](@ref GeneralTwoBand) is ``2|\\vec{h}|``, so the gap at
+``k_x=0`` is ``2\\Delta``. Accordingly, the constructor argument `halfgap` (default
+1.65 eV) yields a physical bandgap of 3.3 eV.
+The default values when given a [`UnitScaling`](@ref UnitScaling)
 object (see Examples below) fit bandgap and dipole at ``k_x=0`` with ``\\hat{x}∥\\Gamma -M``
 to the wurtzite ZnO model used in <https://doi.org/10.1103/PhysRevLett.113.073901>.
 
@@ -38,12 +42,12 @@ isperiodic(::SemiconductorToy1d) = true
 
 function SemiconductorToy1d(
     us::UnitScaling,
-    gap::Unitful.Energy=u"1.65eV",
+    halfgap::Unitful.Energy=u"1.65eV",
     hopping::Unitful.Energy=u"4.30eV",
     latticeconst::Unitful.Length=u"2.82Å")
 
     return SemiconductorToy1d(
-        energyscaled(gap,us),
+        energyscaled(halfgap,us),
         energyscaled(hopping,us),
         lengthscaled(latticeconst,us))
 end


### PR DESCRIPTION
## Summary

Follow-up to #1980, resolving the deferred review finding on the `SemiconductorToy1d` gap convention.

The constructor argument previously named `gap` actually receives **half** the direct bandgap: the `GeneralTwoBand` band splitting is `2|h|`, so with `hx = Δ` the effective gap is 2 × 1.65 eV = 3.3 eV — matching wurtzite ZnO (Ghimire et al. 2010), which the model is fit to. The docstring however documented the Hamiltonian as `(Δ/2)σx`, contradicting the code.

**Why the docs adapt to the code and not the other way around:** changing the stored `Δ` field to the full gap would break loading of existing HDF5 files — `construct_type_from_dict` rebuilds the struct from raw fields, and historical files (including `scripts/published_calculations/SC_toy1d/data.hdf5`) carry half-gap semantics in `Δ`. They would silently reload with a 1.65 eV physical gap.

Changes (behavior-neutral):
- Docstring formula corrected to `H = Δσx − t sin(a kx/2)σz` with an explicit note that `Δ` is half the bandgap and the 1.65 eV default yields the physical 3.3 eV ZnO gap
- Constructor argument renamed `gap` → `halfgap` (positional, so no caller is affected)

## Test plan

- [ ] CI fast tier green on Julia 1.10 / 1.11
- [ ] Documentation workflow validates the (unchanged) doctest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPszA6taBUNsY9bv4rFgxt