### PR TITLE
Docs: add Hamiltonian models page, grouped by periodicity

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,7 +15,8 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
-        "Two-band Hamiltonians" => "twoband.md",
+        "Two-band formalism" => "twoband.md",
+        "Hamiltonian models" => "hamiltonians.md",
         "reference.md",
     ],
 )

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -1,0 +1,43 @@
+# Hamiltonian models
+
+```@meta
+CurrentModule = Damysos
+```
+
+This page lists all concrete Hamiltonians implemented in Damysos. Every model is a
+two-band Hamiltonian of the form ``\hat{H} = \vec{h}(\vec{k})\cdot\vec{\sigma}``
+subtyping [`GeneralTwoBand`](@ref); the machinery for eigenstates and velocity/dipole
+matrix elements is described in the [two-band formalism](twoband.md).
+
+```@docs; canonical=false
+GeneralTwoBand
+```
+
+The models fall into two groups: *periodic* models defined on a lattice with a finite
+Brillouin zone, and *nonperiodic* continuum models. The distinction matters when choosing
+a k-space grid — the `Simulation` constructor enforces the compatible pairing.
+
+## Periodic models
+
+Periodic (tight-binding) models are defined on a lattice, so their Brillouin zone is
+finite and the Hamiltonian is invariant under reciprocal lattice translations. They must
+be paired with a periodic k-space grid sampling exactly one Brillouin zone, i.e.
+[`CartesianMPKGrid1d`](@ref) or [`HexagonalMPKGrid2d`](@ref).
+
+```@docs; canonical=false
+MonolayerhBN
+SemiconductorToy1d
+```
+
+## Nonperiodic models
+
+Nonperiodic models describe a continuum approximation around a band extremum; k-space is
+unbounded and the simulated region is chosen large enough for the physics at hand. They
+are used with the aperiodic Cartesian k-grids such as [`CartesianKGrid1d`](@ref) or
+[`CartesianKGrid2d`](@ref).
+
+```@docs; canonical=false
+GappedDirac
+QuadraticToy
+BilayerToy
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ Documentation for [Damysos](https://github.com/howbgl/Damysos.jl.git).
 
 ## Package features
 
-- Modular building blocks (driving field, Hamiltonian etc. ) for creating simulations
+- Modular building blocks (driving field, Hamiltonian etc. ) for creating simulations, see [Hamiltonian models](hamiltonians.md) for the available Hamiltonians
 - Using velocity-gauge to parallelize over k-points
 - Run any Simulation on GPU or CPU without re-writing any code
 - Built using the powerful [DifferentialEquations.jl](https://github.com/SciML/DiffEqDocs.jl) and [DiffEqGPU.jl](https://github.com/SciML/DiffEqGPU.jl)

--- a/docs/src/twoband.md
+++ b/docs/src/twoband.md
@@ -1,10 +1,11 @@
-# Two-band Hamiltonians
+# Two-band formalism
 
 ```@meta
 CurrentModule = Damysos
 ```
 
 Here we outline the implementation of calculating matrixelements of two-band Hamiltonians.
+For the concrete models implemented in Damysos see [Hamiltonian models](hamiltonians.md).
 
 ## Idea
 

--- a/src/grids/periodic_kgrids.jl
+++ b/src/grids/periodic_kgrids.jl
@@ -110,7 +110,22 @@ function Base.show(
     print(io, prepend_spaces(printfields_generic(kgrid)))
 end
 
-struct CartesianMPKGrid1d{T <: Real} <: PeriodicKGrid{T} 
+"""
+	CartesianMPKGrid1d{T}(dkx, a) <: PeriodicKGrid{T}
+
+One-dimensional Monkhorst-Pack mesh in reciprocal (k-)space for lattice constant `a`.
+
+The Brillouin zone of length ``2π/a`` is sampled with ``q = 2π/(a\\,dk_x)`` (rounded to
+the nearest integer) points; the stored `dkx` is normalized to exactly ``2π/(aq)``.
+
+# Reference
+<https://doi.org/10.1103/PhysRevB.13.5188>
+
+# See also
+[`Simulation`](@ref), [`SymmetricTimeGrid`](@ref), [`HexagonalMPKGrid2d`](@ref),
+[`CartesianKGrid1d`](@ref)
+"""
+struct CartesianMPKGrid1d{T <: Real} <: PeriodicKGrid{T}
     dkx::T
     a::T
     function CartesianMPKGrid1d{T}(dkx::T, a::T) where {T <: Real}

--- a/src/hamiltonians/MonolayerhBN.jl
+++ b/src/hamiltonians/MonolayerhBN.jl
@@ -7,7 +7,7 @@ A tight-binding model for monolayer hexagonal boron nitride (hBN).
 
 The Hamiltonian reads 
 ```math
-\\hat{H} = t[1+2\\sin(a k_x/2)\\cos(\\sqrt{3} k_y a/2)]\\sigma_x - 2t \\cos(a k_x/2)\\sin(\\sqrt{3} k_y a/2)\\sigma_y + \\frac{\\Delta}{2}\\sigma_z
+\\hat{H} = t[1+2\\cos(a k_x/2)\\cos(\\sqrt{3} k_y a/2)]\\sigma_x - 2t \\cos(a k_x/2)\\sin(\\sqrt{3} k_y a/2)\\sigma_y + \\frac{\\Delta}{2}\\sigma_z
 ``` 
 see  <https://doi.org/10.1103/PhysRevB.83.235312> for details.
 
@@ -24,7 +24,7 @@ MonolayerhBN:
 
 # See also
 [`GeneralTwoBand`](@ref GeneralTwoBand) [`GappedDirac`](@ref GappedDirac)
-[`BilayerToy`](@ref BilayerToy) [`SemiconductorToy1d.jl`](@ref SemiconductorToy1d)
+[`BilayerToy`](@ref BilayerToy) [`SemiconductorToy1d`](@ref SemiconductorToy1d)
 """
 struct MonolayerhBN{T<:Real} <: GeneralTwoBand{T} 
     Δ::T


### PR DESCRIPTION
## Summary

- New docs page **Hamiltonian models** (`docs/src/hamiltonians.md`) cataloguing all five concrete Hamiltonians, grouped into **periodic** (`MonolayerhBN`, `SemiconductorToy1d`) and **nonperiodic** (`GappedDirac`, `QuadraticToy`, `BilayerToy`) models, each section explaining which k-grids they pair with
- The existing two-band page stays a separate formalism page (merging would make one overlong page); the two are bidirectionally linked and renamed in the nav to read as a pair: **Two-band formalism** / **Hamiltonian models**
- Landing page links to the new page from the feature list
- All `@docs` blocks use `; canonical=false` since `reference.md`'s `@autodocs` holds the canonical docstrings

Drive-by documentation fixes:
- Added the missing docstring for `CartesianMPKGrid1d` (only exported k-grid without one; also needed for `@ref` links on the new page)
- `MonolayerhBN` docstring formula: σx term corrected to `cos(a kx/2)` to match the code (the code convention is pinned by the FD Jacobian tests and the reciprocal-vector periodicity test)
- Stray `.jl` removed from a `MonolayerhBN` see-also link

## Test plan

- [ ] Documentation workflow builds the new page without Documenter errors
- [ ] CI fast tier green (docstring-only source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPszA6taBUNsY9bv4rFgxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPszA6taBUNsY9bv4rFgxt)_