### PR TITLE
Fix currentvalue MethodError for time grids in ConvergenceTest

### DIFF
--- a/src/autoconverge/methods.jl
+++ b/src/autoconverge/methods.jl
@@ -243,7 +243,7 @@ end
 
 function currentvalue(
 	m::Union{PowerLawTest, LinearTest},
-	grid::KGrid)
+	grid::Union{KGrid, TimeGrid})
 	return getproperty(grid, m.parameter)
 end
 

--- a/test/fast/convergence_unit.jl
+++ b/test/fast/convergence_unit.jl
@@ -1,0 +1,19 @@
+using Damysos
+using Test
+
+import Damysos.currentvalue
+
+@testset "ConvergenceTest unit" begin
+    tgrid = SymmetricTimeGrid(0.1, -5.0)
+    kgrid = CartesianKGrid1d(0.5, 10.0)
+    grid  = NGrid(kgrid, tgrid)
+
+    @testset "currentvalue" begin
+        @test currentvalue(PowerLawTest(:dt, 0.5), tgrid) == 0.1
+        @test currentvalue(PowerLawTest(:kxmax, 0.5), kgrid) == 10.0
+        @test currentvalue(LinearTest(:t0, -1.0), tgrid) == -5.0
+
+        @test currentvalue(PowerLawTest(:dt, 0.5), grid) == 0.1
+        @test currentvalue(PowerLawTest(:kxmax, 0.5), grid) == 10.0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ const TEST_GROUPS = parse_groups(ARGS)
 @testset "Damysos.jl" begin
     if "fast" in TEST_GROUPS
         @testset "fast" begin
+            include(joinpath(@__DIR__, "fast", "convergence_unit.jl"))
             include(joinpath(@__DIR__, "fast", "fieldtests.jl"))
             include(joinpath(@__DIR__, "fast", "matrixelements_smoke.jl"))
             include(joinpath(@__DIR__, "fast", "simulation_smoke.jl"))


### PR DESCRIPTION
Commit 0997e1e narrowed the currentvalue signature from Union{CartesianKGrid, SymmetricTimeGrid} to KGrid, dropping time-grid support. Convergence tests over time-grid parameters like PowerLawTest(:dt, ...) then failed with a MethodError in extrapolate. Restore dispatch via Union{KGrid, TimeGrid} and add a fast-group unit test so this is caught outside the full test group.