### PR TITLE
Overhaul docs: lean README + new manual pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@
 /jupyter/
 *.code-workspace
 /scripts/nhr_fau/
-/docs/builds/
+/docs/build/
 .vscode/
 /test/testresults/

--- a/README.md
+++ b/README.md
@@ -18,220 +18,68 @@ This work is licensed under a
 
 # Damysos.jl
 
+**Damysos.jl** solves the semiconductor Bloch equations (SBEs) for light–matter interaction in
+two-band models on either CPU or GPU. It provides modular building blocks — driving fields,
+Hamiltonians, and grids — that assemble into a `Simulation`, and uses the velocity gauge to
+parallelize the dynamics over k-points. The same simulation runs unchanged on CPU or CUDA GPU(s),
+built on top of [DifferentialEquations.jl](https://github.com/SciML/DiffEqDocs.jl) and
+[DiffEqGPU.jl](https://github.com/SciML/DiffEqGPU.jl).
 
+📖 **[Full documentation](https://howbgl.github.io/Damysos.jl/dev)**
 
 ## Installation
 
-### Install julia
-First make sure you have Julia installed and setup (https://julialang.org/downloads/).
+First make sure you have [Julia](https://julialang.org/downloads/) installed and set up. Since
+Damysos is not yet in the official Julia registry it has to be cloned locally. Go to the desired
+folder and run
 
-### Clone package
-Since Damysos is not yet in the official Julia registry it needs to be cloned locally. Go to the desired folder and run
 ```
 git clone https://github.com/howbgl/Damysos.jl.git
 ```
 
-## Reproducing published data 
-
-Here is a short instruction on how to reproduce data published in <https://doi.org/10.1103/4gwm-9lpy> and available at <https://doi.org/10.5281/zenodo.17828205>. Choose an `.hdf5`-file from the `rawdata` folder in <https://doi.org/10.5281/zenodo.17828205>. Load the file with
+## Quick example
 
 ```julia
-julia> using Damysos,HDF5; file = h5open("rawdata/Fig2_data.hdf5")
-```
-and the desired simulation with
-```julia
-julia> simulation = load_obj_hdf5(file["t2=0.2"]); close(file)
-```
-Choose either the CPU (`LinearChunked(nkchunks::Integer,...)`) or the GPU solver(`LinearCUDA(nkchunks::Integer,...)`) 
-```julia
-julia> solver = LinearChunked(); psim = PreparedSimulation(simulation, solver)
-```
-and run simulation with
-```julia
-julia> results = run!(psim; savepath = "Fig2_rerun")
-```
-An example script with data is located at `scripts/published_calculations/reproduce.jl`.
+using Damysos
 
+df    = GaussianAPulse(2.0, 2π, 1.3)                 # Gaussian vector-potential pulse
+h     = GappedDirac(0.1)                             # gapped Dirac Hamiltonian
+l     = TwoBandDephasingLiouvillian(h, Inf, Inf)     # dynamics + dephasing times
+us    = UnitScaling(u"1/10THz", u"5.5e5m/s" / u"10THz")  # link scaled units to SI
 
-## Testing package
+tgrid = SymmetricTimeGrid(0.01, -5df.σ)              # time grid
+kgrid = CartesianKGrid2d(1.0, 100.0, 1.0, 100.0)     # 2d k-space grid
+grid  = NGrid(kgrid, tgrid)
+obs   = [Velocity(grid), Occupation(grid)]           # observables to compute
 
-Tests are tiered to keep default CI fast while preserving full validation options.
+sim   = Simulation(l, df, grid, obs, us, "my-simulation")
 
-- `fast` (default): small deterministic checks and smoke tests
-- `slow`: CPU regression tests with full simulations
-- `gpu`: CUDA smoke tests (requires functional CUDA)
-- `full`: long-running convergence and multi-GPU validation
-
-Navigate to the package directory and open a Julia prompt via
-```julia
-julia> --project -t auto
-```
-Using multiple threads via `-t auto` is recommended for the `slow` and `full` tiers.
-```julia
-julia> using Damysos, Pkg
-
-julia> Pkg.test("Damysos")  # fast only
-
-julia> Pkg.test("Damysos"; test_args=["slow"])
-julia> Pkg.test("Damysos"; test_args=["gpu"])
-julia> Pkg.test("Damysos"; test_args=["slow","gpu"])
-julia> Pkg.test("Damysos"; test_args=["full"])
-```
-Test output paths can be overridden with `ENV["DAMYSOS_TESTRESULTS_DIR"]`.
-
-## Usage
-
-### Demo script
-
-The script [demo.jl](scripts/demo.jl) shows how to run a single simulation and save the results as well as some automated plots.
-
-### Setting up your own simulation
-
-The `Simulation` object holds information about the physical system as well as numerical parameters.
-The physical system is described by a `Liouvillian` and a `DrivingField` governing the dynamics.
-
-```julia
-julia> using Damysos
-
-julia> df = GaussianAPulse(2.0,2π,1.3)
-GaussianAPulse:
- σ: 2.0
- ν: 1.0
- ω: 6.283185307179586
- eE: 1.3
- φ: 0.0
- ħω: 6.283185307179586
- θ: 0.0
-
-julia> h = GappedDirac(0.1)
-GappedDirac:
- m: 0.1
- vF: 1.0
-
-julia> l = TwoBandDephasingLiouvillian(h,Inf,Inf)
-TwoBandDephasingLiouvillian(GappedDirac)
-  Hamiltonian: GappedDirac
-  m: 0.1
-  vF: 1.0
- t1: Inf
- t2: Inf
-
+result = run!(sim; solver = LinearChunked(2000))
 ```
 
-All quantities above are in scaled units, which are used for all numerical calculations. The `UnitScaling` links these dimensionless quantities to SI units via a characteristic time and length.
-```julia
-julia> us = UnitScaling(u"1/10THz",u"5.5e5m/s" / u"10THz")
-UnitScaling:
- timescale: 100.0 fs
- lengthscale: 55.0 nm
-```
-It is built on the [Unitful.jl](https://github.com/PainterQubits/Unitful.jl) package, thus all units recognized by said package can be used here.
-The period of a $1\,$THz pulse ($T_0=100\,$fs) was chosen as timescale and $l_c=\frac{5.5\times10^5\frac{\mathrm{m}}{\mathrm{s}}}{T_0}$, such that a scaled Fermi velocity of $v_F=1$ corresponds to $5.5\times10^5$m/s.
-We can check this via the builtin conversion methods:
-```julia
-julia> velocitySI(1.0,us)
-550000.0 m s^-1
+See the [Getting started](https://howbgl.github.io/Damysos.jl/dev/tutorial/) guide for a
+step-by-step walkthrough, and [`scripts/demo.jl`](scripts/demo.jl) for a complete example with
+logging and plotting.
 
-julia> velocityscaled(u"5.5e5m/s",us)
-1.0
-```
+## Documentation
 
-The observables to be calculated by the simulation are given via a Vector of `Observable` objects.
-```julia
-julia> obs = [Velocity(l),Occupation(l)]
-2-element Vector{Observable{Float64}}:
- Velocity{Float64}(Float64[], Float64[], Float64[], Float64[], Float64[], Float64[])
- Occupation{Float64}(Float64[])
+- [Getting started](https://howbgl.github.io/Damysos.jl/dev/tutorial/) — build and run a simulation.
+- [Solvers](https://howbgl.github.io/Damysos.jl/dev/solvers/) — CPU vs GPU backends.
+- [Convergence testing](https://howbgl.github.io/Damysos.jl/dev/convergence/) — automatically refine numerical parameters.
+- [Data I/O](https://howbgl.github.io/Damysos.jl/dev/data/) — saving, loading, and reproducing published data.
+- [Two-band formalism](https://howbgl.github.io/Damysos.jl/dev/twoband/) & [Hamiltonian models](https://howbgl.github.io/Damysos.jl/dev/hamiltonians/) — the physics and available models.
 
-```
+## Reproducing published data
 
-The timegrid used for integration is specified via a `TimeGrid` object.
-Momentarily there is only the option of a `SymmetricTimeGrid <: TimeGrid`:
-```julia
-julia> tgrid = SymmetricTimeGrid(0.01,-5df.σ)
-SymmetricTimeGrid:
-  dt: 0.01
-  t0: -10.0
-```
-Integration in k-space is specified via a subtype of `KGrid`.
-At the moment only cartesian grids and a single k-point are implemented, where the object is specific to the type of simulation:
+Data published with Damysos can be reloaded and re-run directly from the archived HDF5 files. See the
+[Data I/O](https://howbgl.github.io/Damysos.jl/dev/data/#Reproducing-published-data) page for a
+walkthrough (using the dataset at <https://doi.org/10.5281/zenodo.17828205>), and
+[`scripts/published_calculations/reproduce.jl`](scripts/published_calculations/reproduce.jl) for a
+ready-to-run script.
 
-1. Single k-mode => `KGrid0d`
-2. One-dimensional Fermi sea => `CartesianKGrid1d`
-3. Two-dimensional Fermi sea => `CartesianKGrid2d`
+## Testing
 
-Time- and k-space grids form an `NGrid`:
-```julia
-julia> kgrid = CartesianKGrid2d(1.0,100,1,100)
-CartesianKGrid2d:
-  dkx: 1.0
-  kxmax: 100.0
-  dky: 1.0
-  kymax: 100.0
-
-
-julia> grid = NGrid(kgrid, tgrid)
-NGrid:
-CartesianKGrid2d:
-  dkx: 1.0
-  kxmax: 100.0
-  dky: 1.0
-  kymax: 100.0
- SymmetricTimeGrid:
-  dt: 0.01
-  t0: -10.0
-```
-
-
-With this we can create the `Simulation` object
-```julia
-julia> sim = Simulation(l,df,grid,obs,us,"simulation-name")
-Simulation{Float64} (2d):
- TwoBandDephasingLiouvillian(GappedDirac)
-   Hamiltonian: GappedDirac
-   m: 0.1
-   vF: 1.0
-  t1: Inf
-  t2: Inf
- GaussianAPulse:
-   σ: 2.0
-   ω: 6.283
-   eE: 1.3
-   φ: 0.0
-   θ: 0.0
-  
- NGrid:
- CartesianKGrid2d:
-   dkx: 1.0
-   kxmax: 100.0
-   dky: 1.0
-   kymax: 100.0
-  SymmetricTimeGrid:
-   dt: 0.01
-   t0: -10.0
-  
- Observables:
-  Velocity
-  Occupation
- UnitScaling:
-  timescale: 100.0 fs
-  lengthscale: 55.0 nm
- id: "simulation-name"
-```
-
-The constructed simulation can then be executed via
-```julia
-julia> result = run!(sim;
-  solver=LinearChunked(2000),
-  saveplots=false,
-  savedata=true)
-```
-
-and the result given back is `sim.observables` (see docs for `run!` for explanation of keyword arguments).
-For maximal performance use `PreparedSimulation` via
-```julia
-julia> const psim = PreparedSimulation(sim, LinearChunked());
-julia> result = run!(psim)
-```
-which pre-defines the functions used in the numerical computations.
-Note that the call to `run!(psim)` must be more recent in world age than the definition of the `PreparedSimulation` (see official Julia [documentation](https://docs.julialang.org/en/v1/manual/worldage/#The-World-Age-mechanism) for info on the world age mechanism), otherwise a `MethodError` will be thrown.
+Tests are tiered (`fast`, `slow`, `gpu`, `full`) to keep default CI fast while preserving full
+validation. Run the default fast tier with `Pkg.test("Damysos")`; see the
+[Testing & development](https://howbgl.github.io/Damysos.jl/dev/testing/) page for the other tiers
+and the CI workflows.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,8 +15,13 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Getting started" => "tutorial.md",
+        "Solvers" => "solvers.md",
+        "Convergence testing" => "convergence.md",
+        "Data I/O" => "data.md",
         "Two-band formalism" => "twoband.md",
         "Hamiltonian models" => "hamiltonians.md",
+        "Testing & development" => "testing.md",
         "reference.md",
     ],
 )

--- a/docs/src/convergence.md
+++ b/docs/src/convergence.md
@@ -1,0 +1,89 @@
+# Convergence testing
+
+```@meta
+CurrentModule = Damysos
+```
+
+Every Damysos [`Simulation`](@ref) discretises time and k-space on finite grids. The physically
+meaningful result is the one obtained in the limit of an infinitely fine (or infinitely large) grid,
+so a numerical parameter — the time step `dt`, the k-spacing `dkx`/`dky`, or the integration cutoff
+`kxmax`/`kymax` — must be refined until the observables of interest stop changing. A
+[`ConvergenceTest`](@ref) automates that sweep: it repeatedly runs the simulation while varying one
+parameter, Richardson-extrapolates the observables, and stops once a target tolerance is reached (or
+a time/iteration budget is exhausted).
+
+## Convergence methods
+
+A [`ConvergenceTestMethod`](@ref) specifies *which* parameter is refined and *how* it changes each
+iteration:
+
+- [`PowerLawTest`](@ref)`(parameter, multiplier)` — multiplies `parameter` by `multiplier` each
+  iteration. Use for parameters best refined geometrically, e.g. halving the time step with
+  `PowerLawTest(:dt, 0.5)`.
+- [`LinearTest`](@ref)`(parameter, shift)` — adds `shift` to `parameter` each iteration.
+- [`ExtendKymaxTest`](@ref)`(method)` — a specialisation that extends the integration region in the
+  ``k_y`` direction by *reusing* previously computed strips instead of recomputing the whole grid.
+  It wraps a `PowerLawTest`/`LinearTest` on `:kymax` and currently requires a Gaussian pulse along
+  ``k_x`` (`φ = 0`).
+
+`parameter` is a `Symbol` naming a field of either the k-grid (e.g. `:dkx`, `:kxmax`, `:kymax`) or
+the time grid (e.g. `:dt`, `:t0`).
+
+## Running a test
+
+Construct a [`ConvergenceTest`](@ref) from a starting [`Simulation`](@ref) and a solver, choosing
+the method and the stopping criteria, then call [`run!`](@ref):
+
+```julia
+using Damysos
+
+sim    = make_test_simulation_tiny()          # any Simulation
+solver = LinearChunked(256)
+
+test = ConvergenceTest(sim, solver;
+    method        = PowerLawTest(:dt, 0.5),   # halve the time step each iteration
+    atolgoal      = 1e-6,
+    rtolgoal      = 1e-2,
+    maxtime       = Inf,
+    maxiterations = 20)
+
+result = run!(test; filepath = "dt_convergence.hdf5")
+
+successful_retcode(result)                    # true if it converged
+```
+
+`run!` returns a [`ConvergenceTestResult`](@ref) and, unless `savedata = false`, writes every
+completed simulation plus the extrapolated result to the given `.hdf5` file. Use
+[`successful_retcode`](@ref) to check whether the test reached its tolerance goal, and
+[`terminated_retcode`](@ref) to check whether it stopped regularly (including hitting the
+`maxtime`/`maxiterations` budget).
+
+The stopping criteria interact as follows: the test ends as soon as **either** the extrapolated
+observables satisfy both `atolgoal` and `rtolgoal`, **or** `maxiterations` simulations have run,
+**or** `maxtime` seconds have elapsed. `maxtime` accepts a plain number of seconds or a Unitful time
+(e.g. `u"60minute"`).
+
+## Resuming from disk
+
+Because each iteration is saved, a test can be reconstructed from its `.hdf5` file and continued —
+for example on a different machine or with a different solver:
+
+```julia
+test = ConvergenceTest("dt_convergence.hdf5", LinearCUDA())
+run!(test)
+```
+
+See the [Data I/O](data.md) page for more on the on-disk format.
+
+## API
+
+```@docs; canonical=false
+ConvergenceTest
+PowerLawTest
+LinearTest
+ExtendKymaxTest
+ConvergenceTestResult
+successful_retcode
+terminated_retcode
+```
+```

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -1,0 +1,87 @@
+# Data I/O
+
+```@meta
+CurrentModule = Damysos
+```
+
+Damysos stores simulations and their results in [HDF5](https://www.hdfgroup.org/solutions/hdf5/)
+files. A saved file contains the full specification of a [`Simulation`](@ref) — driving field,
+Hamiltonian/Liouvillian, grids, unit scaling — alongside the computed observables, so a run can be
+reloaded, inspected, or reproduced later.
+
+## Saving
+
+By default [`run!`](@ref) saves both data and plots when a simulation finishes. This is controlled
+by keyword arguments:
+
+```julia
+run!(sim;
+    savedata = true,               # write observables + simulation to disk
+    saveplots = true,              # write default plots
+    savepath = "myrun")            # target directory (default: joinpath(pwd(), getname(sim)))
+```
+
+To save explicitly, outside of `run!`, use `savedata`:
+
+```julia
+savedata(sim)                      # writes to joinpath(pwd(), getname(sim))
+savedata(sim, "path/to/output")    # writes to a chosen directory
+```
+
+The low-level writer `savedata_hdf5(object, parent)` serialises individual objects (simulations,
+grids, driving fields, …) into an open `HDF5.File`/`HDF5.Group` and is used internally by the
+functions above.
+
+## Loading
+
+`load_obj_hdf5` reconstructs a Damysos object from a file path, or from an already-open
+`HDF5.File`/`HDF5.Group`:
+
+```julia
+using Damysos, HDF5
+
+sim = load_obj_hdf5("myrun/simulation.hdf5")     # from a path
+
+file = h5open("myrun/data.hdf5")                 # or from an open handle / subgroup
+sim  = load_obj_hdf5(file["t2=0.2"])
+close(file)
+```
+
+The set of reconstructable types (simulations, all grid types, Hamiltonians, driving fields,
+observables, and convergence-test methods) is registered internally; older on-disk layouts are
+handled transparently for backwards compatibility.
+
+A [`ConvergenceTest`](@ref) is reloaded with its own constructor, which rebuilds the test from all
+completed iterations stored in the file (see [Convergence testing](convergence.md)):
+
+```julia
+test = ConvergenceTest("dt_convergence.hdf5", LinearChunked())
+```
+
+## Reproducing published data
+
+Data published with Damysos can be reloaded and re-run directly from the archived HDF5 files. The
+following reproduces a figure from [10.1103/4gwm-9lpy](https://doi.org/10.1103/4gwm-9lpy) using the
+dataset archived at [10.5281/zenodo.17828205](https://doi.org/10.5281/zenodo.17828205). Pick an
+`.hdf5` file from that archive's `rawdata` folder and load the desired simulation:
+
+```julia
+using Damysos, HDF5
+
+file       = h5open("rawdata/Fig2_data.hdf5")
+simulation = load_obj_hdf5(file["t2=0.2"])
+close(file)
+```
+
+Choose a solver — the CPU [`LinearChunked`](@ref) or the GPU [`LinearCUDA`](@ref) — wrap the
+simulation in a [`PreparedSimulation`](@ref), and run it:
+
+```julia
+solver  = LinearChunked()
+psim    = PreparedSimulation(simulation, solver)
+results = run!(psim; savepath = "Fig2_rerun")
+```
+
+A complete, runnable script is provided at
+[`scripts/published_calculations/reproduce.jl`](https://github.com/howbgl/Damysos.jl/blob/main/scripts/published_calculations/reproduce.jl).
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,15 @@ Documentation for [Damysos](https://github.com/howbgl/Damysos.jl.git).
 - Run any Simulation on GPU or CPU without re-writing any code
 - Built using the powerful [DifferentialEquations.jl](https://github.com/SciML/DiffEqDocs.jl) and [DiffEqGPU.jl](https://github.com/SciML/DiffEqGPU.jl)
 
+## Manual
+
+- [Getting started](tutorial.md) — build and run your first simulation.
+- [Solvers](solvers.md) — choosing between the CPU and GPU backends.
+- [Convergence testing](convergence.md) — automatically refine numerical parameters.
+- [Data I/O](data.md) — save, load, and reproduce published data.
+- [Two-band formalism](twoband.md) and [Hamiltonian models](hamiltonians.md) — the physics and the available models.
+- [Testing & development](testing.md) — the test tiers and CI workflows.
+
 ## Semiconductor Bloch equations
 
 The computational task for this package consists of solving the Semiconductor Bloch equations (SBEs):

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,0 +1,79 @@
+# Solvers
+
+```@meta
+CurrentModule = Damysos
+```
+
+Damysos exploits the fact that, in the velocity gauge, the [semiconductor Bloch equations](index.md)
+decouple in ``\bm{k}``: each k-point is an independent system of ODEs. A *solver* is the strategy
+for distributing and integrating that ensemble of ODEs.
+All solvers subtype `DamysosSolver` and are selected either through the `solver` keyword of
+[`run!`](@ref) or when constructing a [`PreparedSimulation`](@ref).
+
+The same `Simulation` runs unchanged on any compatible solver, so switching between CPU and GPU
+requires no code changes.
+
+## Choosing a solver
+
+| Solver | Backend | Simulation dimension | Typical use |
+|--------|---------|----------------------|-------------|
+| [`LinearChunked`](@ref) | CPU (threads/processes) | 1d, 2d | Default; portable, no GPU required |
+| [`LinearCUDA`](@ref) | CUDA GPU(s) | 1d, 2d | Large k-grids, best throughput |
+| [`SingleMode`](@ref) | CPU | 0d (single k-point) | Inspecting one k-mode |
+
+A few practical notes:
+
+- **Start on the CPU.** [`LinearChunked`](@ref) needs no special hardware and is the default when
+  no solver is given. For multithreading, start Julia with `-t auto`.
+- **Scale up on the GPU.** [`LinearCUDA`](@ref) computes many k-points concurrently and is the right
+  choice for large two-dimensional k-grids, provided a functional CUDA installation is available. It
+  automatically spreads work across all visible GPUs unless `ngpus` is set.
+- **`kchunksize` is the tuning knob.** Both linear solvers split the k-grid into chunks. Larger
+  chunks improve throughput but use more memory; `LinearCUDA` will automatically subdivide the time
+  axis into slices if a chunk would exceed available GPU memory (reported via a memory-estimate log
+  message), so reduce `kchunksize` if you see that warning frequently.
+
+## CPU: `LinearChunked`
+
+```julia
+julia> solver = LinearChunked()                     # defaults: 256 k-points/chunk, Vern7
+
+julia> solver = LinearChunked(2000)                 # larger chunks
+
+julia> solver = LinearChunked(2000, EnsembleThreads())  # explicit parallelisation
+```
+
+The parallelisation strategy defaults to `EnsembleThreads()` when Julia runs with multiple threads,
+`EnsembleDistributed()` with multiple worker processes, and `EnsembleSerial()` otherwise.
+
+```@docs; canonical=false
+LinearChunked
+```
+
+## GPU: `LinearCUDA`
+
+```julia
+julia> solver = LinearCUDA()                    # all available GPUs, fixed-timestep GPUVern7
+
+julia> solver = LinearCUDA(10_000, GPUVern7(), 1)   # 10⁴ k-points/chunk, single GPU
+
+julia> solver = LinearCUDA(; rtol = 1e-8, atol = 1e-8)  # adaptive time-stepping
+```
+
+Passing `rtol`/`atol` switches the GPU integrator into adaptive mode; leaving them at `nothing`
+(the default) uses a fixed timestep taken from the [`SymmetricTimeGrid`](@ref). `LinearCUDA`
+requires `CUDA.functional()` to be `true`.
+
+```@docs; canonical=false
+LinearCUDA
+```
+
+## Single k-point: `SingleMode`
+
+`SingleMode` integrates a single k-point and is used with a zero-dimensional
+[`KGrid0d`](@ref) simulation.
+
+```@docs; canonical=false
+SingleMode
+```
+```

--- a/docs/src/testing.md
+++ b/docs/src/testing.md
@@ -1,0 +1,77 @@
+# Testing & development
+
+```@meta
+CurrentModule = Damysos
+```
+
+Damysos' test suite is split into tiers so that everyday CI stays fast while the full physical
+validation remains available on demand. This page describes how to run the tiers locally and how
+they map onto the project's continuous-integration workflows.
+
+## Test tiers
+
+| Tier | Contents | Requirements |
+|------|----------|--------------|
+| `fast` (default) | small deterministic checks and smoke tests | none |
+| `slow` | CPU regression tests with full simulations | multithreading recommended |
+| `gpu` | CUDA smoke tests | a functional CUDA GPU |
+| `full` | long-running convergence and multi-GPU validation | GPU(s); long runtime |
+
+Selecting `full` (or `all`) implies every other tier.
+
+## Running the tests
+
+From the package directory, start Julia with multiple threads (recommended for the `slow` and
+`full` tiers):
+
+```
+julia --project -t auto
+```
+
+and select tiers through `test_args`:
+
+```julia
+using Pkg
+
+Pkg.test("Damysos")                              # fast only (default)
+Pkg.test("Damysos"; test_args=["slow"])
+Pkg.test("Damysos"; test_args=["gpu"])
+Pkg.test("Damysos"; test_args=["slow", "gpu"])
+Pkg.test("Damysos"; test_args=["full"])          # everything
+```
+
+Tests write their output (HDF5 files, plots) to a temporary directory by default. To keep the
+results, point `DAMYSOS_TESTRESULTS_DIR` at a directory of your choice:
+
+```
+DAMYSOS_TESTRESULTS_DIR=/path/to/results julia --project -t auto -e 'using Pkg; Pkg.test(test_args=["slow"])'
+```
+
+## Continuous integration
+
+The tiers map onto the workflows in [`.github/workflows/`](https://github.com/howbgl/Damysos.jl/tree/main/.github/workflows):
+
+| Workflow | Trigger | Runs |
+|----------|---------|------|
+| `ci.yml` | every push / pull request | `fast` tier on Julia 1.10 and 1.11 |
+| `slow-regression.yml` | nightly cron + manual | `slow` tier |
+| `gpu.yml` | manual dispatch | `gpu` tier on a self-hosted GPU runner |
+| `full-validation.yml` | manual dispatch | `full` tier |
+| `documentation.yml` | push to `main`, tags, PRs | builds and deploys the docs |
+| `CompatHelper.yml` | daily cron | opens PRs bumping `[compat]` bounds |
+| `TagBot.yml` | release events | creates git tags for registered releases |
+
+Because only the `fast` tier runs on every push, run the heavier tiers locally before opening a pull
+request that touches solver internals, grids, or the convergence machinery.
+
+## Building the documentation locally
+
+The documentation is built with [Documenter.jl](https://documenter.juliadocs.org/). To render it
+locally:
+
+```
+julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'
+```
+
+The generated site is written to `docs/build/`.
+```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -1,0 +1,182 @@
+# Getting started
+
+```@meta
+CurrentModule = Damysos
+```
+
+This page walks through building and running a single [`Simulation`](@ref) from scratch. A
+`Simulation` bundles everything needed for a calculation: the physical system (a
+[`Liouvillian`](@ref) and a [`DrivingField`](@ref)), the numerical grids in time and k-space, the
+[`Observable`](@ref)s to compute, and the [`UnitScaling`](@ref) that links the internal
+dimensionless units to SI units.
+
+A complete, ready-to-run version of the example below is available in
+[`scripts/demo.jl`](https://github.com/howbgl/Damysos.jl/blob/main/scripts/demo.jl).
+
+## Building the physical system
+
+The dynamics are governed by a `Liouvillian`, built from a [`Hamiltonian`](@ref) and dephasing
+times, and a `DrivingField`. Here we use a [`GappedDirac`](@ref) Hamiltonian and a
+[`GaussianAPulse`](@ref) vector-potential pulse:
+
+```julia
+julia> using Damysos
+
+julia> df = GaussianAPulse(2.0, 2π, 1.3)
+GaussianAPulse:
+ σ: 2.0
+ ν: 1.0
+ ω: 6.283185307179586
+ eE: 1.3
+ φ: 0.0
+ ħω: 6.283185307179586
+ θ: 0.0
+
+julia> h = GappedDirac(0.1)
+GappedDirac:
+ m: 0.1
+ vF: 1.0
+
+julia> l = TwoBandDephasingLiouvillian(h, Inf, Inf)
+TwoBandDephasingLiouvillian(GappedDirac)
+  Hamiltonian: GappedDirac
+  m: 0.1
+  vF: 1.0
+ t1: Inf
+ t2: Inf
+```
+
+All quantities above are in *scaled* (dimensionless) units, which are used for every numerical
+calculation. See the [Hamiltonian models](hamiltonians.md) page for the other available
+Hamiltonians.
+
+## Unit scaling
+
+The [`UnitScaling`](@ref) links the dimensionless quantities to SI units via a characteristic time
+and length. It is built on [Unitful.jl](https://github.com/PainterQubits/Unitful.jl), so any unit
+recognised by that package can be used.
+
+```julia
+julia> us = UnitScaling(u"1/10THz", u"5.5e5m/s" / u"10THz")
+UnitScaling:
+ timescale: 100.0 fs
+ lengthscale: 55.0 nm
+```
+
+Here the period of a ``1\,``THz pulse (``T_0 = 100\,``fs) is the timescale and
+``l_c = \frac{5.5\times10^5\,\mathrm{m/s}}{T_0}``, so that a scaled Fermi velocity of ``v_F = 1``
+corresponds to ``5.5\times10^5\,``m/s. Built-in conversion helpers make this explicit:
+
+```julia
+julia> velocitySI(1.0, us)
+550000.0 m s^-1
+
+julia> velocityscaled(u"5.5e5m/s", us)
+1.0
+```
+
+For a convenient way to derive a scaling directly from a driving frequency and Fermi velocity, see
+[`scaledriving_frequency`](@ref), which is used in [`scripts/demo.jl`](https://github.com/howbgl/Damysos.jl/blob/main/scripts/demo.jl).
+
+## Grids
+
+The integration grid in time is a [`TimeGrid`](@ref); currently the only option is a
+[`SymmetricTimeGrid`](@ref):
+
+```julia
+julia> tgrid = SymmetricTimeGrid(0.01, -5df.σ)
+SymmetricTimeGrid:
+  dt: 0.01
+  t0: -10.0
+```
+
+Integration in k-space uses a subtype of [`KGrid`](@ref). The grid type encodes the dimensionality
+of the simulation:
+
+1. Single k-mode ``\Rightarrow`` [`KGrid0d`](@ref)
+2. One-dimensional Fermi sea ``\Rightarrow`` [`CartesianKGrid1d`](@ref)
+3. Two-dimensional Fermi sea ``\Rightarrow`` [`CartesianKGrid2d`](@ref)
+
+Periodic (tight-binding) Hamiltonians require periodic k-grids instead; see
+[Hamiltonian models](hamiltonians.md). The time and k-space grids are combined into an
+[`NGrid`](@ref):
+
+```julia
+julia> kgrid = CartesianKGrid2d(1.0, 100.0, 1.0, 100.0)
+CartesianKGrid2d:
+  dkx: 1.0
+  kxmax: 100.0
+  dky: 1.0
+  kymax: 100.0
+
+julia> grid = NGrid(kgrid, tgrid)
+NGrid:
+CartesianKGrid2d:
+  dkx: 1.0
+  kxmax: 100.0
+  dky: 1.0
+  kymax: 100.0
+ SymmetricTimeGrid:
+  dt: 0.01
+  t0: -10.0
+```
+
+## Observables
+
+The quantities to be computed are given as a `Vector` of [`Observable`](@ref)s constructed from the
+grid:
+
+```julia
+julia> obs = [Velocity(grid), Occupation(grid)]
+2-element Vector{Observable{Float64}}:
+ Velocity{Float64}(Float64[], Float64[], Float64[], Float64[], Float64[], Float64[])
+ Occupation{Float64}(Float64[])
+```
+
+## Assembling and running the simulation
+
+With all components in hand we build the [`Simulation`](@ref):
+
+```julia
+julia> sim = Simulation(l, df, grid, obs, us, "simulation-name")
+```
+
+and run it. Passing a `Simulation` directly to [`run!`](@ref) lets you choose the solver via the
+`solver` keyword:
+
+```julia
+julia> result = run!(sim;
+           solver   = LinearChunked(2000),
+           saveplots = false,
+           savedata  = true)
+```
+
+The return value is `sim.observables`. See the [`run!`](@ref) docstring for the full list of
+keyword arguments (`savedata`, `saveplots`, `savepath`, `showinfo`, `nan_limit`), and the
+[Data I/O](data.md) page for how results are written to disk.
+
+## Reusing functions with `PreparedSimulation`
+
+For maximal performance — for example when running many simulations that share the same physical
+model — pre-compile the numerical functions once into a [`PreparedSimulation`](@ref):
+
+```julia
+julia> const psim = PreparedSimulation(sim, LinearChunked());
+
+julia> result = run!(psim)
+```
+
+!!! warning "World age"
+    The call to `run!(psim)` must be more recent in world age than the definition of the
+    `PreparedSimulation`, otherwise a `MethodError` is thrown. See the Julia manual on the
+    [world age mechanism](https://docs.julialang.org/en/v1/manual/worldage/#The-World-Age-mechanism).
+    When building and running inside the same function, `run!(sim; solver=...)` handles this for you
+    via `invokelatest`.
+
+## Next steps
+
+- [Solvers](solvers.md) — choosing between CPU and GPU backends.
+- [Convergence testing](convergence.md) — automatically refining a numerical parameter until an
+  observable converges.
+- [Data I/O](data.md) — saving and loading simulations, and reproducing published data.
+```

--- a/src/Damysos.jl
+++ b/src/Damysos.jl
@@ -36,15 +36,63 @@ export Liouvillian
 export NGrid
 export PreparedSimulation
 
+"""
+    DamysosSolver
+
+Abstract supertype for the integration strategies that run a [`Simulation`](@ref), such as
+[`LinearChunked`](@ref), [`LinearCUDA`](@ref) and [`SingleMode`](@ref).
+"""
 abstract type DamysosSolver end
+
+"""
+    Observable{T}
+
+Abstract supertype for quantities computed during a [`Simulation`](@ref), such as
+[`Velocity`](@ref) and [`Occupation`](@ref).
+"""
 abstract type Observable{T} end
+
 abstract type SimulationComponent{T} end
+
+"""
+    Hamiltonian{T}
+
+Abstract supertype for the Hamiltonians describing the electronic band structure, such as
+[`GappedDirac`](@ref).
+"""
 abstract type Hamiltonian{T} end
+
+"""
+    KGrid{T}
+
+Abstract supertype for k-space integration grids, such as [`CartesianKGrid2d`](@ref) or
+[`KGrid0d`](@ref).
+"""
 abstract type KGrid{T} end
+
+"""
+    TimeGrid{T}
+
+Abstract supertype for time integration grids, such as [`SymmetricTimeGrid`](@ref).
+"""
 abstract type TimeGrid{T} end
+
 abstract type AperiodicKGrid{T}         <: KGrid{T} end
 abstract type PeriodicKGrid{T}          <: KGrid{T} end
+
+"""
+    Liouvillian{T}
+
+Abstract supertype for the equations of motion governing the density-matrix dynamics, such as
+[`TwoBandDephasingLiouvillian`](@ref).
+"""
 abstract type Liouvillian{T}            <: SimulationComponent{T} end
+
+"""
+    DrivingField{T}
+
+Abstract supertype for the driving fields, such as [`GaussianAPulse`](@ref).
+"""
 abstract type DrivingField{T}           <: SimulationComponent{T} end
 
 

--- a/src/UnitScaling.jl
+++ b/src/UnitScaling.jl
@@ -3,7 +3,7 @@ using Unitful:𝐌
 using Unitful:𝐓
 using Unitful:𝐈
 
-@derived_dimension Vectorpotential 𝐋*𝐌*𝐓^-2*𝐈^-1 true
+@derived_dimension Vectorpotential 𝐋*𝐌*𝐓^-2*𝐈^-1
 
 export UnitScaling
 

--- a/src/autoconverge/structs.jl
+++ b/src/autoconverge/structs.jl
@@ -6,6 +6,12 @@ export ExtendKymaxTest
 export LinearTest
 export PowerLawTest
 
+"""
+    ConvergenceTestMethod
+
+Abstract supertype for the parameter-refinement strategies used by a [`ConvergenceTest`](@ref):
+[`PowerLawTest`](@ref), [`LinearTest`](@ref) and [`ExtendKymaxTest`](@ref).
+"""
 abstract type ConvergenceTestMethod end
 
 @enumx ReturnCode success maxtime maxiter running failed exception nan_abort

--- a/src/drivingfields/DrivingFields.jl
+++ b/src/drivingfields/DrivingFields.jl
@@ -7,6 +7,13 @@ export scaledriving_frequency
 
 gauss(t::T,σ::T) where {T<:Real} = exp(-t^2 / (2σ^2))
 
+"""
+    scaledriving_frequency(frequency, fermivelocity)
+
+Construct a [`UnitScaling`](@ref) from a driving `frequency` and a `fermivelocity` (both Unitful
+quantities), using the driving period as the timescale and `fermivelocity * period` as the
+lengthscale.
+"""
 function scaledriving_frequency(ufrequency,ufermivelocity)
     return scaledriving_frequency(promote(ufrequency,ufermivelocity)...)
 end


### PR DESCRIPTION
Restructure the documentation so the README is a lean landing page and the deep-dive content lives in the Documenter site.

- README: trimmed from ~238 to ~85 lines; added the missing package description and a short runnable quick example; replaced the long simulation walkthrough and testing section with links into the hosted docs.
- New docs pages: Getting started (tutorial.md), Solvers, Convergence testing, Data I/O, and Testing & development, wired into make.jl and linked from index.md.
- Added docstrings to the public abstract types (Observable, Hamiltonian, KGrid, TimeGrid, Liouvillian, DrivingField, DamysosSolver, ConvergenceTestMethod) and scaledriving_frequency so the new pages' cross-references resolve and the API reference is richer.
- Fixed a latent docs-build failure: the stray autodocs flag on the Vectorpotential derived dimension attached a Unitful-sourced docstring that broke Documenter's source-link generation (MissingRemoteError) at render time.
- Fixed a .gitignore typo (/docs/builds/ -> /docs/build/) so generated docs are ignored.