### PR TITLE
Error on saving types missing from LOADABLES instead of silently unta…

### DIFF
--- a/src/data/data_utils.jl
+++ b/src/data/data_utils.jl
@@ -27,7 +27,6 @@ const LOADABLES = Dict(
 	"CompositeDrivingField{.*?}"	=> CompositeDrivingField,
 	"Vector{Observable{.*?}}"		=> Vector{Observable},
 	"VelocityX"						=> VelocityX,
-	"\bVelocity\b"					=> Velocity,
 	"Velocity{.*?}"					=> Velocity,
 	"Occupation"					=> Occupation,
 	"PowerLawTest"					=> PowerLawTest,
@@ -201,9 +200,12 @@ function generic_save_hdf5(object, parent::Union{HDF5.File, HDF5.Group}, grpname
 end
 
 function generic_save_hdf5(object, parent::Union{HDF5.File, HDF5.Group})
-	if isloadable(object)
-		parent["T"] = "$(typeof(object))"
-	end
+	# Refuse to write untagged (i.e. unloadable) data: silently omitting "T" here
+	# used to produce files that load_obj_hdf5 can never reconstruct.
+	isloadable(object) || throw(ArgumentError(
+		"$(typeof(object)) has no matching entry in LOADABLES; register it there " *
+		"before saving, otherwise the file could never be loaded again."))
+	parent["T"] = "$(typeof(object))"
 	for n in fieldnames(typeof(object))
 		parent["$n"] = getproperty(object, n)
 	end


### PR DESCRIPTION
…gging

generic_save_hdf5 wrote the "T" type tag only if the object's type already had a LOADABLES entry, silently producing HDF5 files that load_obj_hdf5 can never reconstruct (KeyError: "T"). This happened twice in production data: Velocity groups written 2025-03 (while the "\bVelocity\b" entry - whose \b are literal backspace bytes, matching nothing - was the only Velocity entry) and SemiconductorToy1d/CartesianMPKGrid1d groups written 2026-01 (before da05e40 registered them).

- generic_save_hdf5 now throws an ArgumentError naming the unregistered type, so missing registrations surface at save time instead of corrupting archives. All existing savedata_hdf5 call sites pass registered types.
- Remove the dead "\bVelocity\b" LOADABLES entry; "Velocity{.*?}" covers it.