### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Damysos"
 uuid = "fd5f980c-983e-4c87-a5d0-4feb611f7d72"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Wolfgang Hogger <wolfgang.hogger@ur.de>"]
 
 [deps]


### PR DESCRIPTION
Minor release: periodic two-band models with Monkhorst-Pack grids, the PreparedSimulation workflow with a new default CPU solver, HDF5 save/load robustness (error on unregistered types), ConvergenceTest fixes and a documentation overhaul. See the release notes.